### PR TITLE
Use 0 padded hour for virt image name

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-F=alpine-virt-image-$(date +%Y-%m-%d-%k%M)
+F=alpine-virt-image-$(date +%Y-%m-%d-%H%M)
 
 if [ "$CI" = "true" ]
 then


### PR DESCRIPTION
Fixes issue when building image before noon and not enough coffee is on
board.