### PR TITLE
Update to latest alpine-make-vm-image for alpine 3.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Note: Need root permission.
 
 This will produce `alpine-virt-image-{timestamp}.qcow2.bz2` which can then be uploaded to Digital Ocean and used to create your droplet. Check out their instructions at https://blog.digitalocean.com/custom-images/ for uploading the image and creating your droplet.
 
-In this commit, the script will produce alpine `version 3.12` image. If you wanna build latest version, you can pull latest alpin-make-vm-image repo: `git submodule foreach git pull origin master`
+In this commit, the script will produce alpine `version 3.15` image. If you wanna build latest version, you can pull latest [alpine-make-vm-image repo](https://github.com/alpinelinux/alpine-make-vm-image): `git submodule foreach git pull origin master`

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -o errexit
+
 F=alpine-virt-image-$(date +%Y-%m-%d-%H%M)
 
 if [ "$CI" = "true" ]

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-F=alpine-virt-image-$(date +%Y-%m-%d-%k%M)
+F=alpine-virt-image-$(date +%Y-%m-%d-%H%M)
 
 if [ "$CI" = "true" ]
 then


### PR DESCRIPTION
Fixes the build-image.sh to exit if any errors occur which was happening when using an outdated alpine-make-vm-image submodule.